### PR TITLE
Setting Content Length on GZip Requests

### DIFF
--- a/src/ring/middleware/gzip.clj
+++ b/src/ring/middleware/gzip.clj
@@ -4,6 +4,8 @@
   (:import (java.util.zip GZIPOutputStream)
            (java.io InputStream
                     OutputStream
+                    ByteArrayOutputStream
+                    ByteArrayInputStream
                     Closeable
                     File
                     PipedInputStream
@@ -52,13 +54,28 @@
         (.close ^Closeable in)))
     pipe-in))
 
-(defn gzipped-response [resp]
-  (-> resp
-      (update-in [:headers]
-                 #(-> %
-                      (assoc "Content-Encoding" "gzip")
-                      (dissoc "Content-Length")))
-      (update-in [:body] piped-gzipped-input-stream)))
+(defn- gzip-into-byte-array? [resp]
+  (if-let [length (get-in resp [:headers "Content-Length"])]
+    (< (Long/parseLong length) 1048576)))
+
+(defn gzipped-response [{:keys [body] :as resp}]
+  (let [gzip-body (piped-gzipped-input-stream body)]
+    (if (gzip-into-byte-array? resp)
+      (let [output-stream (ByteArrayOutputStream.)
+            _ (-> (io/copy gzip-body output-stream))
+            gzip-bytes (.toByteArray output-stream)]
+        (-> resp
+            (update-in [:headers]
+                       #(-> %
+                          (assoc "Content-Encoding" "gzip")
+                          (assoc "Content-Length" (str (count gzip-bytes)))))
+            (assoc :body (ByteArrayInputStream. gzip-bytes))))
+      (-> resp
+          (update-in [:headers]
+                     #(-> %
+                          (assoc "Content-Encoding" "gzip")
+                          (dissoc "Content-Length")))
+          (assoc :body gzip-body)))))
 
 (defn wrap-gzip [handler]
   (fn [req]


### PR DESCRIPTION
This adds a Content-Length to the response, if an original Content-Length was present, and less than 1MB. This prevents jetty from adding Transfer-Encoding: chunked to the response, without requiring Connection: Close